### PR TITLE
Fix bug terminate

### DIFF
--- a/scow-sync-terminate
+++ b/scow-sync-terminate
@@ -2,6 +2,7 @@
 '''
 Kill a file transfer
 '''
+import sys
 import signal
 import psutil
 from argsparser import TerminateArgsParser
@@ -12,16 +13,7 @@ def __parse_cmdline(cmdline):
     '''
     从命令中解析出[user, address, src_path, dst_path]
     '''
-    info = {'rsync': False, 
-            'user': '',
-            'address': '', 
-            'src_path': '', 
-            'dst_path': ''
-        }
-
-    if cmdline[0] != 'rsync':
-        return info
-    info['rsync'] = True
+    info = {'user': '', 'address': '', 'src_path': '', 'dst_path': ''}
 
     # pylint: disable=C0200
     for index in range(len(cmdline)):
@@ -37,27 +29,44 @@ def __parse_cmdline(cmdline):
 
     return info
 
+def find_process(filepath: str, address: str, user: str):
+    '''
+    找到对应的rsync进程。对于一个采用ssh协议传输的rsync进程，其结构通常是:
+    1  |——/bin sh -c rsync
+    2   |——rsync
+    3    |——ssh
+    需要关闭的是2
+    '''
+    rsync_process = None 
+    cmd_info = None
+    for process in psutil.process_iter():
+        cmdline = process.cmdline()
+        if cmdline[0] != 'rsync':
+            continue
+        else:
+            # 检查address, user, src_path是否对的上
+            cmd_info = __parse_cmdline(cmdline)
+            if cmd_info['user'] == user and cmd_info['address'] == address and cmd_info['src_path'] in filepath:
+                rsync_process = process
+                break
+            continue
+    return rsync_process, cmd_info  
 
 def close_process_by_filepath(filepath: str, output_path: str, error_path: str, address: str, user: str):
     '''
     关闭命令中含有该文件路径的进程
     '''
-    for process in psutil.process_iter():
-        try:
-            cmdline = process.cmdline()
-            cmd_info = __parse_cmdline(cmdline)
-
-            # 当命令中含有rsync、文件路径，并且目的地址对应的上、用户对应的上
-            if cmd_info['rsync'] and cmd_info['user'] == user and cmd_info['address'] == address and cmd_info['src_path'] in filepath:
-                # print(cmd_info)
-                process.send_signal(signal.SIGINT)
-                with open(output_path, 'a', encoding='utf-8') as file_stream:
-                    file_stream.write(f'kill transfer: {cmdline}\n')
-                break
-        except Exception as exception:
-            with open(error_path, 'a', encoding='utf-8') as file_stream:
-                file_stream.write(f'kill transfer error: {exception}\n')
-
+    process, cmd_info = find_process(filepath, address, user)
+    if process is None:
+        with open(error_path, 'a', encoding='utf-8') as file_stream:
+            file_stream.write(f'kill transfer error: no process found\n')
+        sys.stderr.write(f'kill transfer error: no process found\n')
+        sys.stderr.flush()
+        sys.exit(-1)
+    else:
+        process.send_signal(signal.SIGINT)
+        with open(output_path, 'a', encoding='utf-8') as file_stream:
+            file_stream.write(f'kill transfer: {cmd_info}\n')
 
 if __name__ == '__main__':
 
@@ -67,3 +76,5 @@ if __name__ == '__main__':
     # 停止进程
     close_process_by_filepath(
         args.source, LOG_PATH, ERROR_PATH, args.address, args.user)
+    
+    sys.exit()

--- a/scowsync.py
+++ b/scowsync.py
@@ -58,7 +58,7 @@ class ScowSync:
         # pylint: disable=W0612
         stdout, stderr = popen.communicate()
         if times < 3:
-            if stderr:
+            if popen.returncode == 255:
                 self.__start_rsync(cmd, fullpath, times+1)
         else:
             if stderr:


### PR DESCRIPTION
该pr修订了一个bug。
因为在线程数量比较多时，rsync会莫名报错断开连接，退出码是255，官方并没有给出解决方案，因此通过重启三次rsync服务保证系统的鲁棒性。
但是由于在判断时，没有通过退出码判断而是通过stderr是否为空判断，这样的判断不够准确，导致scow-sync-terminate的需要调用三次，才能关掉对应的rsync进程。

该pr将通过stderr的判断改为了通过退出码判断，并重构了scow-sync-terminate代码