### PR TITLE
Resolve terminate bug 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,7 @@ It will return an array of json object like:
 
 ### terminate
 
-You can use the following command to terminate the transfer process. But you should note that the shutdown of the process is at the granularity of the rsync service. 
-
-For example, you are using an rsync service to transfer a folder dir, which consists of file1 and file2. When using `-s --source` as the parameter to terminate the transmission with `-s dir/file1`, it actually closes the transmission of the entire folder dir, which is equivalent to `-s dir`.
-
-To prevent this from happening, please increase `-m --max-depth` when starting `scow-sync-start` transmission to increase the parallel granularity.
+You can use the following command to terminate the transfer process. But you should note that the shutdown of the process is at the granularity of the rsync service. It will then restart the rsync service but with `--exclude` to exclude the files that have been terminated.
 
 ```bash
 scow-sync-terminate [-h] [-a ADDRESS] [-u USER] [-s SOURCE] [-p PORT] [-k SSHKEY_PATH]

--- a/scow-sync-start
+++ b/scow-sync-start
@@ -5,8 +5,6 @@ Start a file transfer asynchronously
 import os
 import sys
 from subprocess import PIPE, Popen
-
-import utils
 from argsparser import StartArgsParser
 from config import SCOWSYNC_PATH, LOG_PATH, ERROR_PATH
 

--- a/scow-sync-terminate
+++ b/scow-sync-terminate
@@ -16,7 +16,7 @@ def __parse_cmdline(cmdline):
     '''
     从命令中解析出[user, address, src_path, dst_path, exclude]
     '''
-    info = {'user': '', 'address': '', 'src_path': '', 'dst_path': ''}
+    info = {'user': '', 'address': '', 'src_path': '', 'dst_path': '', 'exclude': ''}
 
     # pylint: disable=C0200
     for index in range(len(cmdline)):
@@ -28,6 +28,9 @@ def __parse_cmdline(cmdline):
             info['dst_path'] = content.split(':')[1]
             # 解析 src_path，即user@addtess:dst_path的前面
             info['src_path'] = cmdline[index - 1]
+        # 解析exclude
+        if content == '--exclude':
+            info['exclude'] += f'{cmdline[index + 1]} '
 
     return info
 
@@ -52,6 +55,14 @@ def find_process(filepath: str, address: str, user: str):
             cmd_info = __parse_cmdline(cmdline)
             if cmd_info['user'] == user and cmd_info['address'] == address and cmd_info['src_path'] in filepath: # 注意，这个地方是子集
                 rsync_process = process
+                # cmd_raw需要做进一步处理，因为rsync子进程中的ssh -p xx -i xx -o xx 没有加引号需要加引号
+                print(cmdline)
+                for index in range(len(cmdline)):
+                    context = cmdline[index]
+                    if context == '-e':
+                        cmdline[index + 1] = f"\'{cmdline[index + 1]}\'"
+                        continue
+                        break
                 cmd_raw = ' '.join(cmdline)
                 break
             continue
@@ -62,11 +73,15 @@ def __restart_rsync(transfer_id, cmd, cmd_info, error_path):
     重启rsync进程
     '''
     output_dir_path = os.path.join(SCOWSYNC_PATH, str(transfer_id))
+    if not os.path.exists(output_dir_path):
+        os.mkdir(output_dir_path, 0o700)
     output_file_path = os.path.join(output_dir_path, os.path.basename(f"{cmd_info['src_path']}.out"))
     with open(output_file_path, 'a', encoding='utf-8') as file_stream:
         # 第一行是关于接收集群和文件（文件夹）的父路径的信息
             file_stream.write(f"{cmd_info['address']} {os.path.dirname(cmd_info['src_path'])}\n")
-    popen = Popen(cmd, stdout=open(output_file_path, 'a', encoding='utf-8'), stderr=open(error_path, 'a', encoding='utf-8'), universal_newlines=True, shell=True)
+    exe_cmd = f'{cmd} && rm -rf {output_dir_path}' # rsync进程执行成功，删掉中间文件
+    print("exe_cmd", exe_cmd)
+    popen = Popen(exe_cmd, stdout=open(output_file_path, 'a', encoding='utf-8'), stderr=open(error_path, 'a', encoding='utf-8'), universal_newlines=True, shell=True)
 
 def close_process_by_filepath(filepath: str, output_path: str, error_path: str, address: str, user: str):
     '''
@@ -75,14 +90,14 @@ def close_process_by_filepath(filepath: str, output_path: str, error_path: str, 
     process, cmd_info, cmd_raw = find_process(filepath, address, user)
     if process is None or cmd_info is None or cmd_raw is None:
         with open(error_path, 'a', encoding='utf-8') as file_stream:
-            file_stream.write(f'kill transfer ${filepath} error: no process found\n')
+            file_stream.write(f'kill transfer {filepath} error: no process found\n')
         sys.stderr.write(f'kill transfer error: no process found\n')
         sys.stderr.flush()
         sys.exit(-1)
     else:
         process.send_signal(signal.SIGINT)
         with open(output_path, 'a', encoding='utf-8') as file_stream:
-            file_stream.write(f'kill transfer ${filepath} completed\n')
+            file_stream.write(f'kill transfer {filepath} completed\n')
             
         # 判断需不需要重启，如果取消的进程只负责传该单个文件，那么就不需要重启，否则需要重启，并将该文件加入到exclude下
         if cmd_info['src_path'] == filepath: # 取消的进程只负责传输单个文件，那么不需要重启，传输进度中间文件会被scowsync主进程清理
@@ -91,9 +106,9 @@ def close_process_by_filepath(filepath: str, output_path: str, error_path: str, 
             # 在rsync规则中，如果要排除某个文件，需要将其相对路径加入到exclude中，而不能是full_path
             relative_path = os.path.relpath(path=filepath, start=cmd_info['src_path'])
             # 生成唯一的transfer_id
-            raw_string = f"{cmd_info['address']} {cmd_info['user']} {cmd_info['src_path']} {cmd_info['dst_path']} {relative_path}"
+            raw_string = f"{cmd_info['address']} {cmd_info['user']} {cmd_info['src_path']} {cmd_info['dst_path']} --exclude {cmd_info['exclude']} {relative_path}"
             transfer_id = utils.gen_file_transfer_id(raw_string)
-            __restart_rsync(transfer_id, cmd_raw + "--exclude=" + relative_path, cmd_info, error_path)
+            __restart_rsync(transfer_id, cmd_raw + " --exclude=" + relative_path, cmd_info, error_path)
     return 
             
 if __name__ == '__main__':

--- a/scow-sync-terminate
+++ b/scow-sync-terminate
@@ -3,15 +3,18 @@
 Kill a file transfer
 '''
 import sys
+import os
 import signal
 import psutil
+import utils
 from argsparser import TerminateArgsParser
-from config import LOG_PATH, ERROR_PATH
+from config import LOG_PATH, ERROR_PATH, SCOWSYNC_PATH
+from subprocess import Popen, PIPE
 
 
 def __parse_cmdline(cmdline):
     '''
-    从命令中解析出[user, address, src_path, dst_path]
+    从命令中解析出[user, address, src_path, dst_path, exclude]
     '''
     info = {'user': '', 'address': '', 'src_path': '', 'dst_path': ''}
 
@@ -25,7 +28,6 @@ def __parse_cmdline(cmdline):
             info['dst_path'] = content.split(':')[1]
             # 解析 src_path，即user@addtess:dst_path的前面
             info['src_path'] = cmdline[index - 1]
-            break
 
     return info
 
@@ -35,10 +37,12 @@ def find_process(filepath: str, address: str, user: str):
     1  |——/bin sh -c rsync
     2   |——rsync
     3    |——ssh
-    需要关闭的是2
+    需要关闭的是
+    @return: (进程, 解析后的cmd列表, cmd原始str)
     '''
     rsync_process = None 
     cmd_info = None
+    cmd_raw = None
     for process in psutil.process_iter():
         cmdline = process.cmdline()
         if cmdline[0] != 'rsync':
@@ -46,28 +50,52 @@ def find_process(filepath: str, address: str, user: str):
         else:
             # 检查address, user, src_path是否对的上
             cmd_info = __parse_cmdline(cmdline)
-            if cmd_info['user'] == user and cmd_info['address'] == address and cmd_info['src_path'] in filepath:
+            if cmd_info['user'] == user and cmd_info['address'] == address and cmd_info['src_path'] in filepath: # 注意，这个地方是子集
                 rsync_process = process
+                cmd_raw = ' '.join(cmdline)
                 break
             continue
-    return rsync_process, cmd_info  
+    return rsync_process, cmd_info, cmd_raw
+
+def __restart_rsync(transfer_id, cmd, cmd_info, error_path):
+    '''
+    重启rsync进程
+    '''
+    output_dir_path = os.path.join(SCOWSYNC_PATH, str(transfer_id))
+    output_file_path = os.path.join(output_dir_path, os.path.basename(f"{cmd_info['src_path']}.out"))
+    with open(output_file_path, 'a', encoding='utf-8') as file_stream:
+        # 第一行是关于接收集群和文件（文件夹）的父路径的信息
+            file_stream.write(f"{cmd_info['address']} {os.path.dirname(cmd_info['src_path'])}\n")
+    popen = Popen(cmd, stdout=open(output_file_path, 'a', encoding='utf-8'), stderr=open(error_path, 'a', encoding='utf-8'), universal_newlines=True, shell=True)
 
 def close_process_by_filepath(filepath: str, output_path: str, error_path: str, address: str, user: str):
     '''
     关闭命令中含有该文件路径的进程
     '''
-    process, cmd_info = find_process(filepath, address, user)
-    if process is None:
+    process, cmd_info, cmd_raw = find_process(filepath, address, user)
+    if process is None or cmd_info is None or cmd_raw is None:
         with open(error_path, 'a', encoding='utf-8') as file_stream:
-            file_stream.write(f'kill transfer error: no process found\n')
+            file_stream.write(f'kill transfer ${filepath} error: no process found\n')
         sys.stderr.write(f'kill transfer error: no process found\n')
         sys.stderr.flush()
         sys.exit(-1)
     else:
         process.send_signal(signal.SIGINT)
         with open(output_path, 'a', encoding='utf-8') as file_stream:
-            file_stream.write(f'kill transfer: {cmd_info}\n')
-
+            file_stream.write(f'kill transfer ${filepath} completed\n')
+            
+        # 判断需不需要重启，如果取消的进程只负责传该单个文件，那么就不需要重启，否则需要重启，并将该文件加入到exclude下
+        if cmd_info['src_path'] == filepath: # 取消的进程只负责传输单个文件，那么不需要重启，传输进度中间文件会被scowsync主进程清理
+            return
+        else:
+            # 在rsync规则中，如果要排除某个文件，需要将其相对路径加入到exclude中，而不能是full_path
+            relative_path = os.path.relpath(filepath, cmd_info['src_path'])
+            # 生成唯一的transfer_id
+            raw_string = f"{cmd_info['address']} {cmd_info['user']} {cmd_info['src_path']} {cmd_info['dst_path']} {relative_path}"
+            transfer_id = utils.gen_file_transfer_id(raw_string)
+            __restart_rsync(transfer_id, cmd_raw + "--exclude=" + relative_path, cmd_info, error_path)
+    return 
+            
 if __name__ == '__main__':
 
     # 获取参数

--- a/scow-sync-terminate
+++ b/scow-sync-terminate
@@ -89,7 +89,7 @@ def close_process_by_filepath(filepath: str, output_path: str, error_path: str, 
             return
         else:
             # 在rsync规则中，如果要排除某个文件，需要将其相对路径加入到exclude中，而不能是full_path
-            relative_path = os.path.relpath(filepath, cmd_info['src_path'])
+            relative_path = os.path.relpath(path=filepath, start=cmd_info['src_path'])
             # 生成唯一的transfer_id
             raw_string = f"{cmd_info['address']} {cmd_info['user']} {cmd_info['src_path']} {cmd_info['dst_path']} {relative_path}"
             transfer_id = utils.gen_file_transfer_id(raw_string)

--- a/scowsync.py
+++ b/scowsync.py
@@ -4,7 +4,6 @@ Transfer files from local to remote server on SCOW
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from multiprocessing import cpu_count
 from subprocess import Popen, PIPE
 import utils
 from filequeue import FileQueue, EntityFile


### PR DESCRIPTION
之前的`scow-sync-terminate`中一直存在的一个bug：
 + 由于在中止某个文件传输的时候，实际上是取消了该传输该文件的rsync进程。但是如果并行粒度不够大的时候，也就是用一个rsync传某个目录下的所有文件的时候，如果取消了一个文件的传输，那么该目录下的其他文件的传输也会被取消。

现在修复了这个bug：
 + 当出现上述状况时。使用取消的进程的原始rsync命令重启，并添加`--exclude`参数来将终止了的文件排除在外，在`SCOWSYNC_PATH`下建立一个新的transfer_id命名的目录，保存重启之后的文件进度，在rsync执行完毕后自动删掉该文件