### PR TITLE
修复了cmdline长度可能为0的bug

### DIFF
--- a/scow-sync-terminate
+++ b/scow-sync-terminate
@@ -48,7 +48,7 @@ def find_process(filepath: str, address: str, user: str):
     cmd_raw = None
     for process in psutil.process_iter():
         cmdline = process.cmdline()
-        if cmdline[0] != 'rsync':
+        if len(cmdline) == 0 or cmdline[0] != 'rsync':
             continue
         else:
             # 检查address, user, src_path是否对的上


### PR DESCRIPTION
在scow-sync-terminate中，取消传输是通过寻找到对应的rsync进程然后发送SIG_INT实现的。
为了提高性能，scow-sync-terminate只会解析以rsync为首的进程，然后进一步处理。
但是需要考虑到进程的cmdline可能为空。