### PR TITLE
feat: 对于文件夹的串行传输，添加了动态压缩功能

### DIFF
--- a/scow_sync/transfer/files_transfer.py
+++ b/scow_sync/transfer/files_transfer.py
@@ -170,10 +170,10 @@ class FilesTransfer:
         print(f'transfering dir: {sub_path}')
         src = os.path.join(os.path.split(self.src_path)[0], sub_path)
         dst = os.path.join(self.dst_path, os.path.split(sub_path)[0])
+        compress_string = '/'.join(self.compress_list)
         cmd = f'rsync -az --progress  -e \'ssh -p {self.port} -i {self.sshkey_path} -o \'LogLevel=QUIET\'\' \
                 {src} {self.user}@{self.address}:{dst} \
-                --partial --inplace'
-
+                --partial --inplace --skip-compress={compress_string}'
         self.__start_rsync(cmd, src, dst, 0)
         return
 

--- a/tests/dynamic_compress/test.sh
+++ b/tests/dynamic_compress/test.sh
@@ -4,7 +4,7 @@ address=localhost
 user=ljz
 source=$(pwd)/send_files
 destination=$(pwd)/recv_files
-max_depth=2
+max_depth=0
 port=2222
 sshkey_path=/home/ljz/.ssh/id_rsa
 


### PR DESCRIPTION
在rsync的[官方手册](https://linux.die.net/man/1/rsync)中提到了，传输文件夹时会自动根据后缀跳过内部已经压缩的文件。
![image](https://github.com/PKUHPC/scow-sync/assets/78996942/edc8950e-d578-4afa-a8a4-1ec726a1be13)
但是在实践中，发现rsync并没有这么做，于是此pr手动通过--skip-compress参数，实现了在串行传输整个文件夹时，跳过其中已经被压缩的文件。
