### PR TITLE
bug: 完成了ssh执行命令的上下文同步

### DIFF
--- a/scow_sync/utils/ssh.py
+++ b/scow_sync/utils/ssh.py
@@ -43,7 +43,10 @@ class SSH:
         try:
             self.__login(self.address, self.user, self.sshkey_path, self.port)
             assert self.ssh
-            _, stdout, stderr =  self.ssh.exec_command(cmd)
+            _, stdout, stderr = self.ssh.exec_command(cmd)
+            # 同步，等ssh命令执行完毕
+            stdout.channel.recv_exit_status()
+            stderr.channel.recv_exit_status()
             return self.__log(cmd, stdout, stderr)
         finally:
             self.__close()


### PR DESCRIPTION
paramiko.SSHClient().exec_command()是一个异步方法，在scow-sync中执行ssh命令时，一般是要根据返回的stdout和stderr执行下一步的逻辑处理，所以我们这里使用stdout.channel.recv_exit_status()做了同步。